### PR TITLE
Fix usage of http.ResponseRecorder

### DIFF
--- a/admin/server_test.go
+++ b/admin/server_test.go
@@ -114,8 +114,10 @@ func TestGetConfig(t *testing.T) {
 			rec := &httptest.ResponseRecorder{}
 
 			srv.rootHandler(rec, test.req)
-			if rec.Code != test.wantCode {
-				t.Errorf("server response code unexpected, got %d want %d", rec.Code, test.wantCode)
+			res := rec.Result()
+
+			if res.StatusCode != test.wantCode {
+				t.Errorf("server response code unexpected, got %d want %d", res.StatusCode, test.wantCode)
 			}
 		})
 	}
@@ -176,8 +178,10 @@ func TestUpdateConfig(t *testing.T) {
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 			srv.rootHandler(rec, req)
-			if rec.Code != test.wantCode {
-				t.Errorf("server response code unexpected, got %d want %d", rec.Code, test.wantCode)
+			res := rec.Result()
+
+			if res.StatusCode != test.wantCode {
+				t.Errorf("server response code unexpected, got %d want %d", res.StatusCode, test.wantCode)
 			}
 			if !proto.Equal(test.cfg.cfg, test.wantCfg) {
 				t.Errorf("configurations differ: got %v, want %v", test.cfg.cfg, test.wantCfg)
@@ -192,8 +196,10 @@ func TestInvalidMethod(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodDelete, "/", nil)
 	srv.rootHandler(rec, req)
-	if rec.Code != http.StatusMethodNotAllowed {
-		t.Errorf("rec.Code = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	res := rec.Result()
+
+	if res.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("StatusCode = %d, want %d", res.StatusCode, http.StatusMethodNotAllowed)
 	}
 }
 

--- a/admin/server_test.go
+++ b/admin/server_test.go
@@ -111,7 +111,7 @@ func TestGetConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			srv := newServer(testPort, goodFakeNb, test.cfg)
-			rec := &httptest.ResponseRecorder{}
+			rec := httptest.NewRecorder()
 
 			srv.rootHandler(rec, test.req)
 			res := rec.Result()
@@ -172,7 +172,7 @@ func TestUpdateConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			srv := newServer(testPort, goodFakeNb, test.cfg)
-			rec := &httptest.ResponseRecorder{}
+			rec := httptest.NewRecorder()
 
 			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(fmt.Sprintf("agency=%s&stopId=%s", test.formAgency, test.formStopID)))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -192,7 +192,7 @@ func TestUpdateConfig(t *testing.T) {
 
 func TestInvalidMethod(t *testing.T) {
 	srv := newServer(testPort, goodFakeNb, &fakeConfig{})
-	rec := &httptest.ResponseRecorder{}
+	rec := httptest.NewRecorder()
 
 	req := httptest.NewRequest(http.MethodDelete, "/", nil)
 	srv.rootHandler(rec, req)


### PR DESCRIPTION
This corrects the way that http.ResponseRecorders are used. In particular, it makes sure to initialize them properly and call the .Result() method before inspecting.